### PR TITLE
Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine
+
+WORKDIR /var/certs
+
+RUN apk add openssl
+RUN openssl req  -nodes -new -x509  -keyout key.pem -out cert.pem -subj "/C=/ST=/L=/O=/OU=/CN="
+
+WORKDIR /var/vdo/webserver
+COPY . .
+RUN npm install
+
+ADD --keep-git-dir=true https://github.com/steveseguin/vdo.ninja.git /var/vdo/vdo.ninja
+WORKDIR /var/vdo/vdo.ninja
+RUN sed -i 's/\/\/ session\.customWSS = true;/session\.wss = "wss:\/\/"+window\.location\.hostname+":8443";session\.customWSS = true;session.configuration = {}/' ./index.html
+
+EXPOSE 443
+
+ENV KEY_PATH=/var/certs/key.pem
+ENV CERT_PATH=/var/certs/cert.pem
+
+CMD ["node", "/var/vdo/webserver/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM node:20-alpine
 
-WORKDIR /var/certs
-
-RUN apk add openssl
-RUN openssl req  -nodes -new -x509  -keyout key.pem -out cert.pem -subj "/C=/ST=/L=/O=/OU=/CN="
 
 WORKDIR /var/vdo/webserver
 COPY . .
@@ -13,9 +9,8 @@ ADD --keep-git-dir=true https://github.com/steveseguin/vdo.ninja.git /var/vdo/vd
 WORKDIR /var/vdo/vdo.ninja
 RUN sed -i 's/\/\/ session\.customWSS = true;/session\.wss = "wss:\/\/"+window\.location\.host;session\.customWSS = true;session.configuration = {}/' ./index.html
 
-EXPOSE 443
+ENV PORT=8443
 
-ENV KEY_PATH=/var/certs/key.pem
-ENV CERT_PATH=/var/certs/cert.pem
+EXPOSE 8443
 
 CMD ["node", "/var/vdo/webserver/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install
 
 ADD --keep-git-dir=true https://github.com/steveseguin/vdo.ninja.git /var/vdo/vdo.ninja
 WORKDIR /var/vdo/vdo.ninja
-RUN sed -i 's/\/\/ session\.customWSS = true;/session\.wss = "wss:\/\/"+window\.location\.hostname+":8443";session\.customWSS = true;session.configuration = {}/' ./index.html
+RUN sed -i 's/\/\/ session\.customWSS = true;/session\.wss = "wss:\/\/"+window\.location\.host;session\.customWSS = true;session.configuration = {}/' ./index.html
 
 EXPOSE 443
 

--- a/server.js
+++ b/server.js
@@ -107,5 +107,5 @@ websocketServer.on('connection', (webSocketClient) => {
 
 app.use('/', express.static(path.join(__dirname, './../vdo.ninja/')))
 
-const port = 8443
+const port = process.env.PORT ?? 443
 server.listen(port, () => { console.log(`Server started on port ${port}`) });

--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ var express = require("express");
 var app = express();
 var WebSocket = require("ws");
 var cors = require('cors');
+var path = require("path");
 
 
 const key = fs.readFileSync(process.env.KEY_PATH ?? "./key.pem"); /// UPDATE THIS PATH
@@ -104,4 +105,7 @@ websocketServer.on('connection', (webSocketClient) => {
   webSocketClient.on('close', function(reasonCode, description) {});
 });
 
-server.listen(process.env.PORT ?? 443, () => { console.log(`Server started on port 443`) });
+app.use('/', express.static(path.join(__dirname, './../vdo.ninja/')))
+
+const port = process.env.PORT ?? 443
+server.listen(port, () => { console.log(`Server started on port ${port}`) });

--- a/server.js
+++ b/server.js
@@ -107,5 +107,5 @@ websocketServer.on('connection', (webSocketClient) => {
 
 app.use('/', express.static(path.join(__dirname, './../vdo.ninja/')))
 
-const port = process.env.PORT ?? 443
+const port = 8443
 server.listen(port, () => { console.log(`Server started on port ${port}`) });


### PR DESCRIPTION
Fixes #1 

### How to use

1. Mount your certificates
2. Set environment variables `CERT_PATH` and `KEY_PATH` for the certificate and private key respectively
3. Bind port 8443
    3.1. **Note:** the port _can_ be different but you may run into issues where port is hardcoded to be 8443

#### Example

```
docker run --mount type=bind,source="$(pwd)"/certs,target=/var/certs -e KEY_PATH=/var/certs/private.key -e CERT_PATH=/var/certs/certificate.crt -p 8443:8443 vdoninja
```